### PR TITLE
更新mac可用等宽字体

### DIFF
--- a/marketch.sketchplugin/Contents/Sketch/index.html
+++ b/marketch.sketchplugin/Contents/Sketch/index.html
@@ -145,7 +145,7 @@ input[type=text], textarea {outline:0;padding:3px;}
                 .pa-block dt em {position:absolute;visibility:hidden;top:0;right:0;padding:0 10px 0 0;color:#20E8B4;}
                 .copy-success dt em {visibility:visible;}
             .pa-block dd {}
-                .pa-block textarea {padding:10px;border-radius:3px;width:174px;height:19px;border:0;color:#b3b8bd;background:#434950;resize:none;overflow-y:scroll;font-size:11px;font-family:Consolas;}
+                .pa-block textarea {padding:10px;border-radius:3px;width:174px;height:19px;border:0;color:#b3b8bd;background:#434950;resize:none;overflow-y:scroll;font-size:11px;font-family:monospace,Consolas;}
 
         /* 导出 */
         .pa-export {overflow:hidden;}


### PR DESCRIPTION
Consolas 在mac下呈现不了，在font-family补了一个monospace